### PR TITLE
Split amuxctl into amuxctl library and amuxctl binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ AML=$(if $(AML_SRC),$(BUILDDIR)/libasound_pcm_amux.so)
 # Amux control program
 ACTL_SRCDIR=amuxctl
 ACTL_BUILDDIR=$(BUILDDIR)/actl
-ACTL_SRC=main.c pcmlist.c opt.c
+ACTL_SRC=main.c amuxctl.c pcmlist.c opt.c
 ACTL_OBJ=$(ACTL_SRC:%.c=$(ACTL_BUILDDIR)/%.o)
 ACTL_DEPEND=$(ACTL_SRC:%.c=$(ACTL_BUILDDIR)/%.d)
 ACTL_LDFLAGS= -lasound

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,11 @@ AML=$(if $(AML_SRC),$(BUILDDIR)/libasound_pcm_amux.so)
 # Amux control program
 ACTL_SRCDIR=amuxctl
 ACTL_BUILDDIR=$(BUILDDIR)/actl
-ACTL_SRC=main.c amuxctl.c pcmlist.c opt.c
-ACTL_OBJ=$(ACTL_SRC:%.c=$(ACTL_BUILDDIR)/%.o)
-ACTL_DEPEND=$(ACTL_SRC:%.c=$(ACTL_BUILDDIR)/%.d)
-ACTL_LDFLAGS= -lasound
-ACTL=$(if $(ACTL_SRC),$(BUILDDIR)/amuxctl)
+ACTL_BIN_SRC=main.c amuxctl.c pcmlist.c opt.c
+ACTL_BIN_OBJ=$(ACTL_BIN_SRC:%.c=$(ACTL_BUILDDIR)/%.o)
+ACTL_BIN_DEPEND=$(ACTL_BIN_SRC:%.c=$(ACTL_BUILDDIR)/%.d)
+ACTL_BIN_LDFLAGS= -lasound
+ACTL_BIN=$(if $(ACTL_BIN_SRC),$(BUILDDIR)/amuxctl)
 
 ifeq ($(DEBUG),1)
 ACTL_CFLAGS+=-ggdb -fno-omit-frame-pointer -fsanitize=address -fsanitize=leak
@@ -47,13 +47,13 @@ define rm-dir
 $(if $(1), (rmdir $(1) > /dev/null 2>&1) || true)
 endef
 
-all: $(AML) $(ACTL)
+all: $(AML) $(ACTL_BIN)
 
 $(AML): $(AML_OBJ)
 	gcc -shared -o $@ $^ $(LDFLAGS) $(AML_LDFLAGS)
 
-$(ACTL): $(ACTL_OBJ)
-	gcc -o $@ $^ $(LDFLAGS) $(ACTL_LDFLAGS)
+$(ACTL_BIN): $(ACTL_BIN_OBJ)
+	gcc -o $@ $^ $(LDFLAGS) $(ACTL_BIN_LDFLAGS)
 
 $(AML_BUILDDIR)/%.o: $(AML_SRCDIR)/%.c
 	@mkdir -p $(dir $(@))
@@ -70,16 +70,16 @@ amlclean:
 	$(call rm-dir,$(AML_BUILDDIR))
 
 actlclean:
-	$(call rm-file,$(ACTL_OBJ))
-	$(call rm-file,$(ACTL_DEPEND))
-	$(call rm-dir,$(call reverse,$(dir $(ACTL_OBJ))))
+	$(call rm-file,$(ACTL_BIN_OBJ))
+	$(call rm-file,$(ACTL_BIN_DEPEND))
+	$(call rm-dir,$(call reverse,$(dir $(ACTL_BIN_OBJ))))
 	$(call rm-dir,$(ACTL_BUILDDIR))
 
 amldistclean: amlclean
 	$(call rm-file,$(AML))
 
 actldistclean: actlclean
-	$(call rm-file,$(ACTL))
+	$(call rm-file,$(ACTL_BIN))
 
 .PHONY: clean
 

--- a/amuxctl/amuxctl.c
+++ b/amuxctl/amuxctl.c
@@ -67,8 +67,10 @@ static int amux_cfg_parse(struct amux_ctx *ctx)
 
 	ret = -EINVAL;
 	str = cfg_get_str(dft, "type");
-	if((str == NULL) || (strcmp(str, "amux") != 0))
+	if((str == NULL) || (strcmp(str, "amux") != 0)) {
+		fprintf(stderr, "Cannot find config for amux plugin\n");
 		goto unref;
+	}
 
 	str = cfg_get_str(dft, "file");
 	if(str == NULL)
@@ -184,8 +186,10 @@ int amux_ctx_init(struct amux_ctx *actx)
 	}
 
 	ret = amux_cfg_parse(actx);
-	if(ret != 0)
+	if(ret != 0) {
+		fprintf(stderr, "Cannot parse config\n");
 		goto clean;
+	}
 
 	return 0;
 clean:

--- a/amuxctl/amuxctl.c
+++ b/amuxctl/amuxctl.c
@@ -1,0 +1,207 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/file.h>
+
+#include <alsa/asoundlib.h>
+
+#include "amuxctl.h"
+#include "pcmlist.h"
+
+struct amux_ctx {
+	snd_config_t *top;
+	char const *file;
+	struct pcmlst plst;
+};
+
+/*
+ * Add stub for missing snd_config_{ref,unref} added in 1.1.2
+ */
+#if (SND_LIB_VERSION < ((1 << 16) | (1 << 8) | (2 << 8)))
+void snd_config_ref(snd_config_t *top)
+{
+	(void)top;
+}
+
+void snd_config_unref(snd_config_t *top)
+{
+	(void)top;
+}
+#endif
+
+static char const *cfg_get_str(snd_config_t *cfg, char const *key)
+{
+	char const *str = NULL;
+	snd_config_t *entry;
+	int ret;
+
+	ret = snd_config_search(cfg, key, &entry);
+	if(ret < 0) {
+		fprintf(stderr, "Cannot get default cfg node for %s\n", key);
+		goto out;
+	}
+
+	ret = snd_config_get_string(entry, &str);
+	if(ret < 0) {
+		fprintf(stderr, "Cannot get default cfg value for %s\n", key);
+		str = NULL;
+		goto out;
+	}
+out:
+	return str;
+}
+
+static int amux_cfg_parse(struct amux_ctx *ctx)
+{
+	snd_config_t *dft;
+	char const *str;
+	int ret;
+
+	ctx->top = snd_config;
+	snd_config_ref(ctx->top);
+
+	ret = snd_config_search(ctx->top, "pcm.default", &dft);
+	if(ret < 0) {
+		fprintf(stderr, "Cannot get default config\n");
+		goto err;
+	}
+
+	ret = -EINVAL;
+	str = cfg_get_str(dft, "type");
+	if((str == NULL) || (strcmp(str, "amux") != 0))
+		goto unref;
+
+	str = cfg_get_str(dft, "file");
+	if(str == NULL)
+		goto unref;
+
+	ctx->file = str;
+	return 0;
+unref:
+	snd_config_unref(ctx->top);
+	snd_config_update_free_global();
+err:
+	return ret;
+}
+
+void amux_pcmlst_dump(struct amux_ctx *actx)
+{
+	pcmlst_dump(&actx->plst);
+}
+
+int amux_pcm_set(struct amux_ctx *actx, char const *pcm)
+{
+	size_t totsz, cursz;
+	ssize_t sz;
+	int fd = -1, ret;
+
+	ret = open(actx->file, O_WRONLY);
+	if(ret < 0)
+		goto out;
+
+	fd = ret;
+	totsz = strlen(pcm);
+	cursz = 0;
+
+	ret = flock(fd, LOCK_EX);
+	if(ret < 0) {
+		ret = -errno;
+		goto close;
+	}
+
+	while(cursz < totsz) {
+		sz = write(fd, pcm + cursz, totsz - cursz);
+		if(sz <= 0) {
+			ret = (int)sz;
+			goto unlock;
+		}
+		cursz += sz;
+	}
+
+	ret = ftruncate(fd, totsz);
+
+unlock:
+	flock(fd, LOCK_UN);
+close:
+	close(fd);
+out:
+	return ret;
+}
+
+int amux_pcm_get(struct amux_ctx *actx, char *pcm, size_t len)
+{
+	size_t cursz;
+	ssize_t sz;
+	int fd = -1, ret;
+
+	ret = open(actx->file, O_RDONLY);
+	if(ret < 0)
+		goto out;
+
+	fd = ret;
+	cursz = 0;
+
+	ret = flock(fd, LOCK_SH);
+	if(ret < 0) {
+		ret = -errno;
+		goto close;
+	}
+
+	sz = 1;
+	while(sz != 0) {
+		sz = read(fd, pcm + cursz, len - cursz);
+		if(sz < 0) {
+			ret = (int)sz;
+			goto unlock;
+		}
+		cursz += sz;
+	}
+	ret = cursz;
+
+unlock:
+	flock(fd, LOCK_UN);
+close:
+	close(fd);
+out:
+	return ret;
+}
+
+struct amux_ctx *amux_ctx_new() {
+	struct amux_ctx *actx = NULL;
+
+	actx = calloc(1, sizeof(*actx));
+
+	return actx;
+}
+
+int amux_ctx_init(struct amux_ctx *actx)
+{
+	int ret;
+
+	ret = pcmlst_init(&actx->plst);
+	if(ret != 0) {
+		fprintf(stderr, "Cannot initialize PCM list\n");
+		goto err;
+	}
+
+	ret = amux_cfg_parse(actx);
+	if(ret != 0)
+		goto clean;
+
+	return 0;
+clean:
+	pcmlst_cleanup(&actx->plst);
+err:
+	return ret;
+}
+
+void amux_ctx_cleanup(struct amux_ctx *actx)
+{
+	snd_config_unref(actx->top);
+	/* Cleanup alsalib mess */
+	snd_config_update_free_global();
+	pcmlst_cleanup(&actx->plst);
+}
+
+void amux_ctx_free(struct amux_ctx *actx) {
+	free(actx);
+}

--- a/amuxctl/amuxctl.h
+++ b/amuxctl/amuxctl.h
@@ -1,0 +1,30 @@
+#ifndef _AMUXCTL_H_
+#define _AMUXCTL_H_
+
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct amux_ctx;
+
+struct amux_ctx *amux_ctx_new();
+
+int amux_ctx_init(struct amux_ctx *actx);
+
+void amux_pcmlst_dump(struct amux_ctx *actx);
+
+int amux_pcm_set(struct amux_ctx *actx, char const *pcm);
+
+int amux_pcm_get(struct amux_ctx *actx, char *pcm, size_t len);
+
+void amux_ctx_cleanup(struct amux_ctx *actx);
+
+void amux_ctx_free(struct amux_ctx *actx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/amuxctl/main.c
+++ b/amuxctl/main.c
@@ -1,198 +1,14 @@
 #include <stdlib.h>
 #include <stdio.h>
-#include <sys/file.h>
+#include <string.h>
 
-#include <alsa/asoundlib.h>
-
-#include "pcmlist.h"
+#include "amuxctl.h"
 #include "opt.h"
-
-struct amux_ctx {
-	snd_config_t *top;
-	char const *file;
-	struct pcmlst plst;
-};
-
-/*
- * Add stub for missing snd_config_{ref,unref} added in 1.1.2
- */
-#if (SND_LIB_VERSION < ((1 << 16) | (1 << 8) | (2 << 8)))
-void snd_config_ref(snd_config_t *top)
-{
-	(void)top;
-}
-
-void snd_config_unref(snd_config_t *top)
-{
-	(void)top;
-}
-#endif
-
-static char const *cfg_get_str(snd_config_t *cfg, char const *key)
-{
-	char const *str = NULL;
-	snd_config_t *entry;
-	int ret;
-
-	ret = snd_config_search(cfg, key, &entry);
-	if(ret < 0) {
-		fprintf(stderr, "Cannot get default cfg node for %s\n", key);
-		goto out;
-	}
-
-	ret = snd_config_get_string(entry, &str);
-	if(ret < 0) {
-		fprintf(stderr, "Cannot get default cfg value for %s\n", key);
-		str = NULL;
-		goto out;
-	}
-out:
-	return str;
-}
-
-static int amux_cfg_parse(struct amux_ctx *ctx)
-{
-	snd_config_t *dft;
-	char const *str;
-	int ret;
-
-	ctx->top = snd_config;
-	snd_config_ref(ctx->top);
-
-	ret = snd_config_search(ctx->top, "pcm.default", &dft);
-	if(ret < 0) {
-		fprintf(stderr, "Cannot get default config\n");
-		goto err;
-	}
-
-	ret = -EINVAL;
-	str = cfg_get_str(dft, "type");
-	if((str == NULL) || (strcmp(str, "amux") != 0))
-		goto unref;
-
-	str = cfg_get_str(dft, "file");
-	if(str == NULL)
-		goto unref;
-
-	ctx->file = str;
-	return 0;
-unref:
-	snd_config_unref(ctx->top);
-	snd_config_update_free_global();
-err:
-	return ret;
-}
-
-static int amux_pcm_set(struct amux_ctx *actx, char const *pcm)
-{
-	size_t totsz, cursz;
-	ssize_t sz;
-	int fd = -1, ret;
-
-	ret = open(actx->file, O_WRONLY);
-	if(ret < 0)
-		goto out;
-
-	fd = ret;
-	totsz = strlen(pcm);
-	cursz = 0;
-
-	ret = flock(fd, LOCK_EX);
-	if(ret < 0) {
-		ret = -errno;
-		goto close;
-	}
-
-	while(cursz < totsz) {
-		sz = write(fd, pcm + cursz, totsz - cursz);
-		if(sz <= 0) {
-			ret = (int)sz;
-			goto unlock;
-		}
-		cursz += sz;
-	}
-
-	ret = ftruncate(fd, totsz);
-
-unlock:
-	flock(fd, LOCK_UN);
-close:
-	close(fd);
-out:
-	return ret;
-}
-
-static int amux_pcm_get(struct amux_ctx *actx, char *pcm, size_t len)
-{
-	size_t cursz;
-	ssize_t sz;
-	int fd = -1, ret;
-
-	ret = open(actx->file, O_RDONLY);
-	if(ret < 0)
-		goto out;
-
-	fd = ret;
-	cursz = 0;
-
-	ret = flock(fd, LOCK_SH);
-	if(ret < 0) {
-		ret = -errno;
-		goto close;
-	}
-
-	sz = 1;
-	while(sz != 0) {
-		sz = read(fd, pcm + cursz, len - cursz);
-		if(sz < 0) {
-			ret = (int)sz;
-			goto unlock;
-		}
-		cursz += sz;
-	}
-	ret = cursz;
-
-unlock:
-	flock(fd, LOCK_UN);
-close:
-	close(fd);
-out:
-	return ret;
-}
-
-static int amux_ctx_init(struct amux_ctx *actx)
-{
-	int ret;
-
-	ret = pcmlst_init(&actx->plst);
-	if(ret != 0) {
-		fprintf(stderr, "Cannot initialize PCM list\n");
-		goto err;
-	}
-
-	ret = amux_cfg_parse(actx);
-	if(ret != 0)
-		goto clean;
-
-	return 0;
-clean:
-	pcmlst_cleanup(&actx->plst);
-err:
-	return ret;
-}
-
-static void amux_ctx_cleanup(struct amux_ctx *actx)
-{
-	snd_config_unref(actx->top);
-	/* Cleanup alsalib mess */
-	snd_config_update_free_global();
-	pcmlst_cleanup(&actx->plst);
-}
 
 int main(int argc, char *argv[])
 {
 	struct am_opt opt;
-	struct amux_ctx actx;
+	struct amux_ctx *actx = NULL;
 	char pcm[256];
 	int ret;
 
@@ -201,21 +17,26 @@ int main(int argc, char *argv[])
 		goto out;
 	}
 
-	ret = amux_ctx_init(&actx);
+	actx = amux_ctx_new();
+	if(actx == NULL) {
+		goto out;
+	}
+
+	ret = amux_ctx_init(actx);
 	if(ret != 0)
 		goto out;
 
 	switch(opt.act) {
 	case AA_LIST:
-		pcmlst_dump(&actx.plst);
+		amux_pcmlst_dump(actx);
 		break;
 	case AA_SET:
-		ret = amux_pcm_set(&actx, opt.sopt.pcm);
+		ret = amux_pcm_set(actx, opt.sopt.pcm);
 		if(ret != 0)
 			fprintf(stderr, "Can't set PCM: %s\n", strerror(-ret));
 		break;
 	case AA_GET:
-		ret = amux_pcm_get(&actx, pcm, sizeof(pcm));
+		ret = amux_pcm_get(actx, pcm, sizeof(pcm));
 		if(ret < 0)
 			fprintf(stderr, "Can't get PCM: %s\n", strerror(-ret));
 		printf("Current PCM: %.*s\n", ret, pcm);
@@ -224,7 +45,10 @@ int main(int argc, char *argv[])
 		break;
 	}
 
-	amux_ctx_cleanup(&actx);
+	amux_ctx_cleanup(actx);
 out:
+	if(actx) {
+		amux_ctx_free(actx);
+	}
 	return ret;
 }

--- a/amuxctl/main.c
+++ b/amuxctl/main.c
@@ -19,12 +19,15 @@ int main(int argc, char *argv[])
 
 	actx = amux_ctx_new();
 	if(actx == NULL) {
+		perror("amux_ctx_new");
 		goto out;
 	}
 
 	ret = amux_ctx_init(actx);
-	if(ret != 0)
+	if(ret != 0) {
+		fprintf(stderr, "Cannot initialize amux context\n");
 		goto out;
+	}
 
 	switch(opt.act) {
 	case AA_LIST:


### PR DESCRIPTION
This will help third-parties add tools on top of amuxctl library instead or relying calling amuxctl binary.